### PR TITLE
add config overlay for biometric sensors

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -329,4 +329,13 @@
 
     <!-- Brand value for attestation of misprovisioned device. -->
     <string name="config_misprovisionedBrandValue" translatable="false">htc</string>
+
+    <!-- List of biometric sensors on the device, in decreasing strength. Consumed by AuthService
+         when registering authenticators with BiometricService. Format must be ID:Modality:Strength,
+         where: IDs are unique per device, Modality as defined in BiometricAuthenticator.java,
+         and Strength as defined in Authenticators.java -->
+    <string-array name="config_biometric_sensors" translatable="false" >
+        <!-- ID0:Fingerprint:Strong -->
+        <item>0:2:15</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
Related to GrapheneOS/os_issue_tracker#325 and GrapheneOS/os_issue_tracker#326

0:2:15 is the value found in the product overlays for the walleye and taimen factory images. However, I don't have those devices, so this hasn't been tested to see if they fix the linked issues.